### PR TITLE
Output redirected to log file instead of stdout

### DIFF
--- a/Boost.bat
+++ b/Boost.bat
@@ -1,4 +1,8 @@
+rem creating log file
+copy nul log.dat > nul
+
 REM --> Check for Admin permissions
+echo "Check for Admin permissions" >> log.dat
 
 >nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
 
@@ -6,6 +10,7 @@ if '%errorlevel%' NEQ '0' (
 goto UACPrompt
 ) else ( goto gotAdmin )
 :UACPrompt
+echo "Requesting admin privilege" >> log.dat
 echo Set UAC = CreateObject^("Shell.Application"^) > "%temp%\getadmin.vbs"
 
 echo UAC.ShellExecute "%~s0", "", "", "runas", 1 >> "%temp%\getadmin.vbs"
@@ -14,26 +19,29 @@ echo UAC.ShellExecute "%~s0", "", "", "runas", 1 >> "%temp%\getadmin.vbs"
 
 exit /B
 :gotAdmin
+echo "Admin permission granted" >> log.dat
 if exist "%temp%\getadmin.vbs" ( del "%temp%\getadmin.vbs" )
 pushd "%CD%"
 CD /D "%~dp0"
 
-@echo off
-del /s /f /q c:\windows\temp\*.*
-rd /s /q c:\windows\temp
-md c:\windows\temp
-del /s /f /q C:\WINDOWS\Prefetch
+echo "Clearing Windows temporary files"
+echo "Clearing Windows temporary files " >> log.dat
+echo . >> log.dat
+del /s /f /q c:\windows\temp\*.* >> log.dat 2>&1 
+del /s /f /q C:\WINDOWS\Prefetch >> log.dat 2>&1
+deltree.bat /s /q /f c:\windows\temp >> log.dat 2>&1
+deltree.bat /s /q /f c:\windows\tempor~1 >> log.dat 2>&1
+deltree.bat /s /q /f c:\windows\ff*.tmp >> log.dat 2>&1
+deltree.bat /s /q /f c:\windows\tmp >> log.dat 2>&1
+
+echo "Deleting User Temporary Files" 
+echo "Deleting User Temporary Files" >> log.dat 2>&1
 del /s /f /q %temp%\*.*
-rd /s /q %temp%
-md %temp%
-deltree.bat /s /q /f c:\windows\temp
-deltree.bat /s /q /f c:\windows\tempor~1
-deltree.bat /s /q /f c:\windows\ff*.tmp
-deltree.bat /s /q /f c:\windows\tmp
-deltree.bat /s /q /f c:\windows\cookies
-deltree.bat /s /q /f c:\windows\history
-deltree.bat /s /q /f c:\windows\spool\printers
-deltree.bat /s /q /f c:\windows\recent
-del c:\WIN386.SWP
+
+deltree.bat /s /q /f c:\windows\cookies >> log.dat 2>&1
+deltree.bat /s /q /f c:\windows\history >> log.dat 2>&1
+deltree.bat /s /q /f c:\windows\spool\printers >> log.dat 2>&1
+deltree.bat /s /q /f c:\windows\recent >> log.dat 2>&1
+del c:\WIN386.SWP >> log.dat 2>&1
 pause
 cls


### PR DESCRIPTION
Redirecting output to file instead of stdout not only increases speed drastically but also helps in debugging in case of errors.
